### PR TITLE
Add user profile data and friends functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a fully functional Steam Library MCP (Model Context Protocol) server that provides access to Steam game library data through Claude Desktop. The project is built using FastMCP and provides 8 tools for interacting with Steam library data.
+
+## Key Commands
+
+### Running the Server
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run the MCP server (uses STDIO transport for Claude Desktop)
+python mcp_server.py
+
+# Fetch fresh Steam library data (requires .env with STEAM_ID and STEAM_API_KEY)
+python steam_library_fetcher.py
+```
+
+### Configuration
+```bash
+# Create configuration from example
+cp claude_desktop_config.example.json claude_desktop_config.json
+# Edit paths in claude_desktop_config.json to match your system
+# Copy to Claude Desktop location (macOS): ~/Library/Application Support/Claude/claude_desktop_config.json
+```
+
+## Architecture & Structure
+
+### Core Components
+
+1. **mcp_server.py**: Fully functional MCP server with 8 Steam library tools
+   - Uses SQLite database for data storage via SQLAlchemy
+   - Converts playtime from minutes to hours for readability
+   - Uses STDIO transport (not HTTP) for Claude Desktop integration
+   - **CRITICAL**: Never print to stdout during operation as it breaks STDIO protocol
+
+2. **steam_library_fetcher.py**: Steam API data fetcher
+   - Fetches comprehensive game data from Steam API
+   - Fetches user profile data including Steam level and XP
+   - Requires `.env` file with `STEAM_ID` and `STEAM_API_KEY`
+   - Stores data in SQLite database
+
+3. **database.py**: SQLAlchemy models and database management
+   - Defines relational data model for games, users, genres, reviews, etc.
+   - Handles many-to-many relationships properly
+   - Uses SQLite for efficient querying and data integrity
+
+### Implemented MCP Tools
+
+1. **search_games**: Case-insensitive partial search across name, genres, developers, publishers
+2. **filter_games**: Filter by playtime range, review summary, maturity rating
+3. **get_game_details**: Get full game details by name or appid (supports partial matching)
+4. **get_game_reviews**: Get review statistics including calculated positive percentage
+5. **get_library_stats**: Structured dict with totals, top genres/developers, review distribution
+6. **get_recently_played**: Games with playtime_2weeks > 0, sorted by recent playtime
+7. **get_recommendations**: Personalized suggestions with reasons based on favorite genres/developers
+8. **get_user_info**: Get comprehensive user profile including:
+   - Basic info (persona_name, steam_id, profile_url)
+   - Steam level and XP
+   - Account age (calculated from time_created)
+   - Location (country/state if public)
+   - Avatar URLs (small, medium, large)
+   - Library stats (total games, total playtime hours)
+
+### Configuration Files
+
+- **claude_desktop_config.example.json**: Template for users to customize
+- **claude_desktop_config.json**: Personal config (gitignored)
+- **.env**: Steam API credentials (gitignored)
+
+## Important Development Notes
+
+- **STDIO Protocol**: Never use `print()` statements in mcp_server.py as they interfere with Claude Desktop communication
+- **Database**: Uses SQLite database (`steam_library.db`) with SQLAlchemy ORM
+- **Error Handling**: Tools return empty lists/None for missing data rather than raising exceptions
+- **Performance**: Database queries are optimized with proper indexes and relationships
+- **User Profile**: Fetches Steam level, XP, and profile data from Steam's IPlayerService API
+
+## Claude Desktop Integration
+
+- Server name: "steam-library-mcp"
+- Transport: STDIO (not HTTP/SSE)
+- Config location (macOS): `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Requires restart of Claude Desktop after config changes

--- a/database.py
+++ b/database.py
@@ -63,6 +63,16 @@ game_categories = Table(
     Column('category_id', Integer, ForeignKey('categories.category_id'), primary_key=True)
 )
 
+# Association table for friends relationships
+friends_association = Table(
+    'friends',
+    Base.metadata,
+    Column('user_steam_id', String, ForeignKey('user_profile.steam_id'), primary_key=True),
+    Column('friend_steam_id', String, ForeignKey('user_profile.steam_id'), primary_key=True),
+    Column('relationship', String),  # 'friend' or 'all'
+    Column('friend_since', Integer)  # Unix timestamp
+)
+
 # Models
 class UserProfile(Base):
     __tablename__ = 'user_profile'
@@ -83,6 +93,20 @@ class UserProfile(Base):
     
     # Relationships
     games = relationship("UserGame", back_populates="user", cascade="all, delete-orphan")
+    friends = relationship(
+        "UserProfile",
+        secondary=friends_association,
+        primaryjoin=steam_id == friends_association.c.user_steam_id,
+        secondaryjoin=steam_id == friends_association.c.friend_steam_id,
+        back_populates="friend_of"
+    )
+    friend_of = relationship(
+        "UserProfile", 
+        secondary=friends_association,
+        primaryjoin=steam_id == friends_association.c.friend_steam_id,
+        secondaryjoin=steam_id == friends_association.c.user_steam_id,
+        back_populates="friends"
+    )
 
 class Game(Base):
     __tablename__ = 'games'

--- a/database.py
+++ b/database.py
@@ -70,9 +70,15 @@ class UserProfile(Base):
     steam_id = Column(String, primary_key=True)
     persona_name = Column(String)
     profile_url = Column(String)
-    avatar_url = Column(String)
-    account_created = Column(Integer)
-    steam_level = Column(Integer)
+    avatar_url = Column(String)  # Small avatar
+    avatarmedium = Column(String)  # Medium avatar URL
+    avatarfull = Column(String)  # Full avatar URL
+    time_created = Column(Integer)  # Account creation timestamp
+    account_created = Column(Integer)  # Deprecated - use time_created
+    loccountrycode = Column(String)  # Country code (e.g., "US")
+    locstatecode = Column(String)  # State/region code (e.g., "CA")
+    xp = Column(Integer)  # Raw XP value
+    steam_level = Column(Integer)  # Calculated from XP
     last_updated = Column(Integer, default=lambda: int(datetime.now().timestamp()))
     
     # Relationships

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -17,14 +17,16 @@ Steam Library Database Schema
 │ persona_name    │ │   │ name            │  │  │ review_summary  │
 │ profile_url     │ │   │ maturity_rating │  │  │ review_score    │
 │ avatar_url      │ │   │ required_age    │  │  │ total_reviews   │
-│ account_created │ │   │ content_desc... │  │  │ positive_reviews│
-│ steam_level     │ │   │ release_date    │  │  │ negative_reviews│
-│ last_updated    │ │   │ metacritic_score│  │  │ last_updated    │
-└─────────────────┘ │   │ steam_deck_ver. │  │  └─────────────────┘
-                    │   │ controller_sup. │  │
-                    │   │ vr_support      │  │
-                    │   │ last_updated    │  │
-                    │   └─────────────────┘  │
+│ avatarmedium    │ │   │ content_desc... │  │  │ positive_reviews│
+│ avatarfull      │ │   │ release_date    │  │  │ negative_reviews│
+│ time_created    │ │   │ metacritic_score│  │  │ last_updated    │
+│ account_created │ │   │ steam_deck_ver. │  │  └─────────────────┘
+│ loccountrycode  │ │   │ controller_sup. │  │
+│ locstatecode    │ │   │ vr_support      │  │
+│ xp              │ │   │ last_updated    │  │
+│ steam_level     │ │   └─────────────────┘  │
+│ last_updated    │ │                        │
+└─────────────────┘ │                        │
                     │                        │
                     │   ┌─────────────────┐  │
                     └──│   user_games    │  │
@@ -84,9 +86,15 @@ Stores Steam user account information.
 | `steam_id` | STRING (PK) | 64-bit Steam ID |
 | `persona_name` | STRING | Steam display name |
 | `profile_url` | STRING | Steam profile URL |
-| `avatar_url` | STRING | Profile avatar image URL |
-| `account_created` | INTEGER | Unix timestamp of account creation |
-| `steam_level` | INTEGER | Steam level |
+| `avatar_url` | STRING | Small profile avatar image URL |
+| `avatarmedium` | STRING | Medium profile avatar image URL |
+| `avatarfull` | STRING | Full/large profile avatar image URL |
+| `time_created` | INTEGER | Unix timestamp of account creation |
+| `account_created` | INTEGER | Deprecated - use time_created |
+| `loccountrycode` | STRING | Country code (e.g., "US") if public |
+| `locstatecode` | STRING | State/region code (e.g., "CA") if public |
+| `xp` | INTEGER | Raw Steam XP value |
+| `steam_level` | INTEGER | Steam level calculated from XP |
 | `last_updated` | INTEGER | Unix timestamp of last profile update |
 
 #### `games`

--- a/steam_library_fetcher.py
+++ b/steam_library_fetcher.py
@@ -24,6 +24,7 @@ import sys
 import time
 from datetime import datetime
 import logging
+import argparse
 from typing import Dict, List, Optional, Any
 from dotenv import load_dotenv
 import requests
@@ -31,7 +32,7 @@ import requests
 from database import (
     get_db, create_database, get_or_create,
     Game, UserGame, Genre, Developer, Publisher, Category, 
-    GameReview, UserProfile
+    GameReview, UserProfile, friends_association
 )
 
 # Set up logging
@@ -50,6 +51,11 @@ class SteamLibraryFetcher:
         })
         self.rate_limit_delay = 1.0  # Seconds between API calls
         self.last_api_call = 0
+        # Cache control attributes
+        self.cache_days = 7  # Default to 7 days
+        self.force_refresh = False
+        self.skip_games = False
+        self.fetch_friends = False
         
     def _rate_limit(self):
         """Implement rate limiting to avoid hitting API limits"""
@@ -58,6 +64,24 @@ class SteamLibraryFetcher:
         if time_since_last_call < self.rate_limit_delay:
             time.sleep(self.rate_limit_delay - time_since_last_call)
         self.last_api_call = time.time()
+    
+    def _is_game_cached(self, app_id: int) -> bool:
+        """Check if game data is recent enough to skip fetching"""
+        if self.force_refresh:
+            return False
+            
+        with get_db() as session:
+            game = session.query(Game).filter_by(app_id=app_id).first()
+            if not game:
+                return False
+                
+            # Check if last_updated is within cache threshold
+            if game.last_updated:
+                cache_age_seconds = int(datetime.now().timestamp()) - game.last_updated
+                cache_age_days = cache_age_seconds / (24 * 60 * 60)
+                return cache_age_days < self.cache_days
+            
+            return False
         
     def get_owned_games(self, steam_id: str) -> List[Dict]:
         """Get list of games owned by the user using direct Steam Web API"""
@@ -156,15 +180,15 @@ class SteamLibraryFetcher:
             
         return None
         
-    def get_player_summaries(self, steam_id: str) -> Optional[Dict]:
-        """Get player profile information from Steam API"""
-        logger.info(f"Fetching player profile for Steam ID: {steam_id}")
+    def get_player_summaries(self, steam_ids: str) -> List[Dict]:
+        """Get player profile information from Steam API (supports single ID or comma-separated list)"""
+        logger.info(f"Fetching player profile(s) for Steam ID(s): {steam_ids}")
         
         try:
             url = "http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/"
             params = {
                 'key': self.api_key,
-                'steamids': steam_id,
+                'steamids': steam_ids,
                 'format': 'json'
             }
             
@@ -173,23 +197,18 @@ class SteamLibraryFetcher:
             if response.status_code == 200:
                 data = response.json()
                 if 'response' in data and 'players' in data['response']:
-                    players = data['response']['players']
-                    if players and len(players) > 0:
-                        return players[0]
-                    else:
-                        logger.error("No player data found in response")
-                        return None
+                    return data['response']['players']
                 else:
                     logger.error("Invalid response structure")
-                    return None
+                    return []
             else:
                 logger.error(f"Steam API returned {response.status_code}")
                 logger.error(f"Response: {response.text}")
-                return None
+                return []
                 
         except Exception as e:
             logger.error(f"Error fetching player summaries: {e}")
-            return None
+            return []
     
     def get_player_badges(self, steam_id: str) -> Optional[Dict]:
         """Get player badges and XP information from Steam API"""
@@ -250,14 +269,152 @@ class SteamLibraryFetcher:
                 break
                 
         return level
+    
+    def get_friend_list(self, steam_id: str) -> List[Dict]:
+        """Get friend list from Steam API"""
+        logger.info(f"Fetching friend list for Steam ID: {steam_id}")
+        
+        try:
+            url = "http://api.steampowered.com/ISteamUser/GetFriendList/v0001/"
+            params = {
+                'key': self.api_key,
+                'steamid': steam_id,
+                'relationship': 'friend',
+                'format': 'json'
+            }
+            
+            response = self.session.get(url, params=params, timeout=30)
+            
+            if response.status_code == 200:
+                data = response.json()
+                if 'friendslist' in data and 'friends' in data['friendslist']:
+                    friends = data['friendslist']['friends']
+                    logger.info(f"Found {len(friends)} friends")
+                    return friends
+                else:
+                    logger.error("No friends found in response")
+                    return []
+            elif response.status_code == 401:
+                logger.error("Unauthorized - check your API key")
+                return []
+            else:
+                logger.error(f"Steam API returned {response.status_code}")
+                logger.error(f"Response: {response.text}")
+                return []
+                
+        except Exception as e:
+            logger.error(f"Error fetching friend list: {e}")
+            return []
+    
+    def save_user_profile(self, player_data: Optional[Dict], steam_id: str, include_badges: bool = False):
+        """Save or update a user profile (reusable for main user and friends)
+        
+        Args:
+            player_data: Player data from Steam API (None if API call failed)
+            steam_id: Steam ID to save
+            include_badges: Whether to fetch and save XP/level data (only for main user)
+        """
+        with get_db() as session:
+            user = session.query(UserProfile).filter_by(steam_id=steam_id).first()
+            
+            if player_data:
+                # Extract profile data from API response
+                persona_name = player_data.get('personaname', '')
+                profile_url = player_data.get('profileurl', '')
+                avatar = player_data.get('avatar', '')
+                avatarmedium = player_data.get('avatarmedium', '')
+                avatarfull = player_data.get('avatarfull', '')
+                time_created = player_data.get('timecreated', 0)
+                loccountrycode = player_data.get('loccountrycode', '')
+                locstatecode = player_data.get('locstatecode', '')
+                
+                # Get XP and level data only for main user
+                xp = 0
+                steam_level = 0
+                if include_badges:
+                    badges_data = self.get_player_badges(steam_id)
+                    if badges_data:
+                        xp = badges_data.get('player_xp', 0)
+                        steam_level = badges_data.get('player_level', 0)
+                        logger.info(f"Player XP: {xp}, Level: {steam_level}")
+                
+                if not user:
+                    user = UserProfile(
+                        steam_id=steam_id,
+                        persona_name=persona_name,
+                        profile_url=profile_url,
+                        avatar_url=avatar,
+                        avatarmedium=avatarmedium,
+                        avatarfull=avatarfull,
+                        time_created=time_created,
+                        account_created=time_created,  # For backwards compatibility
+                        loccountrycode=loccountrycode,
+                        locstatecode=locstatecode,
+                        xp=xp,
+                        steam_level=steam_level,
+                        last_updated=int(datetime.now().timestamp())
+                    )
+                    session.add(user)
+                    logger.info(f"Created user profile for: {persona_name} (Steam ID: {steam_id})")
+                else:
+                    # Update existing user profile
+                    user.persona_name = persona_name
+                    user.profile_url = profile_url
+                    user.avatar_url = avatar
+                    user.avatarmedium = avatarmedium
+                    user.avatarfull = avatarfull
+                    user.time_created = time_created
+                    user.account_created = time_created  # For backwards compatibility
+                    user.loccountrycode = loccountrycode
+                    user.locstatecode = locstatecode
+                    if include_badges:
+                        user.xp = xp
+                        user.steam_level = steam_level
+                    user.last_updated = int(datetime.now().timestamp())
+                    logger.info(f"Updated user profile for: {persona_name} (Steam ID: {steam_id})")
+                
+                session.commit()
+            else:
+                # Create minimal profile if API call failed
+                if not user:
+                    user = UserProfile(
+                        steam_id=steam_id,
+                        last_updated=int(datetime.now().timestamp())
+                    )
+                    session.add(user)
+                    session.commit()
+                    logger.info(f"Created minimal user profile for Steam ID: {steam_id}")
         
     def process_game(self, game: Dict, index: int, total: int) -> Dict:
         """Process a single game and gather all required information"""
         appid = game.get('appid')
         name = game.get('name', 'Unknown')
         
+        # Check if we should skip games entirely
+        if self.skip_games:
+            logger.debug(f"Skipping game details for {name} (--skip-games flag)")
+            return {
+                'appid': appid,
+                'name': name,
+                'playtime_forever': game.get('playtime_forever', 0),
+                'playtime_2weeks': game.get('playtime_2weeks', 0),
+                'skip_details': True
+            }
+        
+        # Check if data is fresh enough to skip API calls
+        if self._is_game_cached(appid):
+            logger.info(f"Processing [{index}/{total}]: {name} (AppID: {appid}) - Using cached data")
+            # Return minimal data - the save_to_database will only update playtime
+            return {
+                'appid': appid,
+                'name': name,
+                'playtime_forever': game.get('playtime_forever', 0),
+                'playtime_2weeks': game.get('playtime_2weeks', 0),
+                'skip_details': True
+            }
+        
         # Progress indicator
-        logger.info(f"Processing [{index}/{total}]: {name} (AppID: {appid})")
+        logger.info(f"Processing [{index}/{total}]: {name} (AppID: {appid}) - Fetching fresh data")
         
         game_info = {
             'appid': appid,
@@ -338,6 +495,7 @@ class SteamLibraryFetcher:
         """Save game data to SQLite database using SQLAlchemy"""
         with get_db() as session:
             app_id = game_data['appid']
+            skip_details = game_data.get('skip_details', False)
             
             # Create or update game
             game = session.query(Game).filter_by(app_id=app_id).first()
@@ -345,78 +503,80 @@ class SteamLibraryFetcher:
                 game = Game(
                     app_id=app_id,
                     name=game_data['name'],
-                    maturity_rating=game_data['maturity_rating'],
-                    required_age=game_data['required_age'],
-                    content_descriptors=game_data['content_descriptors'],
-                    release_date=game_data['release_date'],
-                    last_updated=int(datetime.now().timestamp())
+                    maturity_rating=game_data.get('maturity_rating'),
+                    required_age=game_data.get('required_age', 0),
+                    content_descriptors=game_data.get('content_descriptors'),
+                    release_date=game_data.get('release_date'),
+                    last_updated=int(datetime.now().timestamp()) if not skip_details else None
                 )
                 session.add(game)
                 session.flush()
-            else:
-                # Update existing game data
+            elif not skip_details:
+                # Update existing game data only if we have fresh details
                 game.name = game_data['name']
-                game.maturity_rating = game_data['maturity_rating']
-                game.required_age = game_data['required_age']
-                game.content_descriptors = game_data['content_descriptors']
-                game.release_date = game_data['release_date']
+                game.maturity_rating = game_data.get('maturity_rating')
+                game.required_age = game_data.get('required_age', 0)
+                game.content_descriptors = game_data.get('content_descriptors')
+                game.release_date = game_data.get('release_date')
                 game.last_updated = int(datetime.now().timestamp())
             
-            # Handle genres
-            if game_data['genres']:
-                # Clear existing genres for this game
-                game.genres.clear()
-                for genre_name in game_data['genres'].split(', '):
-                    if genre_name.strip():
-                        genre = get_or_create(session, Genre, genre_name=genre_name.strip())
-                        game.genres.append(genre)
-            
-            # Handle developers
-            if game_data['developers']:
-                game.developers.clear()
-                for dev_name in game_data['developers'].split(', '):
-                    if dev_name.strip():
-                        developer = get_or_create(session, Developer, developer_name=dev_name.strip())
-                        game.developers.append(developer)
-            
-            # Handle publishers
-            if game_data['publishers']:
-                game.publishers.clear()
-                for pub_name in game_data['publishers'].split(', '):
-                    if pub_name.strip():
-                        publisher = get_or_create(session, Publisher, publisher_name=pub_name.strip())
-                        game.publishers.append(publisher)
-            
-            # Handle categories
-            if game_data['categories']:
-                game.categories.clear()
-                for cat_name in game_data['categories'].split(', '):
-                    if cat_name.strip():
-                        category = get_or_create(session, Category, category_name=cat_name.strip())
-                        game.categories.append(category)
-            
-            # Handle reviews
-            if game_data['review_summary'] != 'Unknown' or game_data['total_reviews'] > 0:
-                review = session.query(GameReview).filter_by(app_id=app_id).first()
-                if not review:
-                    review = GameReview(
-                        app_id=app_id,
-                        review_summary=game_data['review_summary'],
-                        review_score=game_data['review_score'],
-                        total_reviews=game_data['total_reviews'],
-                        positive_reviews=game_data['positive_reviews'],
-                        negative_reviews=game_data['negative_reviews'],
-                        last_updated=int(datetime.now().timestamp())
-                    )
-                    session.add(review)
-                else:
-                    # Update existing review
-                    review.review_summary = game_data['review_summary']
-                    review.review_score = game_data['review_score']
-                    review.total_reviews = game_data['total_reviews']
-                    review.positive_reviews = game_data['positive_reviews']
-                    review.negative_reviews = game_data['negative_reviews']
-                    review.last_updated = int(datetime.now().timestamp())
+            # Skip detailed updates if we're using skip_details
+            if not skip_details:
+                # Handle genres
+                if game_data.get('genres'):
+                    # Clear existing genres for this game
+                    game.genres.clear()
+                    for genre_name in game_data['genres'].split(', '):
+                        if genre_name.strip():
+                            genre = get_or_create(session, Genre, genre_name=genre_name.strip())
+                            game.genres.append(genre)
+                
+                # Handle developers
+                if game_data.get('developers'):
+                    game.developers.clear()
+                    for dev_name in game_data['developers'].split(', '):
+                        if dev_name.strip():
+                            developer = get_or_create(session, Developer, developer_name=dev_name.strip())
+                            game.developers.append(developer)
+                
+                # Handle publishers
+                if game_data.get('publishers'):
+                    game.publishers.clear()
+                    for pub_name in game_data['publishers'].split(', '):
+                        if pub_name.strip():
+                            publisher = get_or_create(session, Publisher, publisher_name=pub_name.strip())
+                            game.publishers.append(publisher)
+                
+                # Handle categories
+                if game_data.get('categories'):
+                    game.categories.clear()
+                    for cat_name in game_data['categories'].split(', '):
+                        if cat_name.strip():
+                            category = get_or_create(session, Category, category_name=cat_name.strip())
+                            game.categories.append(category)
+                
+                # Handle reviews
+                if game_data.get('review_summary', 'Unknown') != 'Unknown' or game_data.get('total_reviews', 0) > 0:
+                    review = session.query(GameReview).filter_by(app_id=app_id).first()
+                    if not review:
+                        review = GameReview(
+                            app_id=app_id,
+                            review_summary=game_data.get('review_summary', 'Unknown'),
+                            review_score=game_data.get('review_score', 0),
+                            total_reviews=game_data.get('total_reviews', 0),
+                            positive_reviews=game_data.get('positive_reviews', 0),
+                            negative_reviews=game_data.get('negative_reviews', 0),
+                            last_updated=int(datetime.now().timestamp())
+                        )
+                        session.add(review)
+                    else:
+                        # Update existing review
+                        review.review_summary = game_data.get('review_summary', 'Unknown')
+                        review.review_score = game_data.get('review_score', 0)
+                        review.total_reviews = game_data.get('total_reviews', 0)
+                        review.positive_reviews = game_data.get('positive_reviews', 0)
+                        review.negative_reviews = game_data.get('negative_reviews', 0)
+                        review.last_updated = int(datetime.now().timestamp())
             
             # Handle user game data
             user_game = session.query(UserGame).filter_by(
@@ -444,80 +604,10 @@ class SteamLibraryFetcher:
         # Create database tables if they don't exist
         create_database()
         
-        # Fetch user profile data from Steam API
-        player_data = self.get_player_summaries(steam_id)
-        
-        # Create or update user profile
-        with get_db() as session:
-            user = session.query(UserProfile).filter_by(steam_id=steam_id).first()
-            
-            if player_data:
-                # Extract profile data from API response
-                persona_name = player_data.get('personaname', '')
-                profile_url = player_data.get('profileurl', '')
-                avatar = player_data.get('avatar', '')
-                avatarmedium = player_data.get('avatarmedium', '')
-                avatarfull = player_data.get('avatarfull', '')
-                time_created = player_data.get('timecreated', 0)
-                loccountrycode = player_data.get('loccountrycode', '')
-                locstatecode = player_data.get('locstatecode', '')
-                
-                # Get XP and level data from badges endpoint
-                badges_data = self.get_player_badges(steam_id)
-                if badges_data:
-                    xp = badges_data.get('player_xp', 0)
-                    steam_level = badges_data.get('player_level', 0)
-                    logger.info(f"Player XP: {xp}, Level: {steam_level}")
-                else:
-                    # Fallback: try to calculate from XP if we have it
-                    xp = 0
-                    steam_level = 0
-                
-                if not user:
-                    user = UserProfile(
-                        steam_id=steam_id,
-                        persona_name=persona_name,
-                        profile_url=profile_url,
-                        avatar_url=avatar,
-                        avatarmedium=avatarmedium,
-                        avatarfull=avatarfull,
-                        time_created=time_created,
-                        account_created=time_created,  # For backwards compatibility
-                        loccountrycode=loccountrycode,
-                        locstatecode=locstatecode,
-                        xp=xp,
-                        steam_level=steam_level,
-                        last_updated=int(datetime.now().timestamp())
-                    )
-                    session.add(user)
-                    logger.info(f"Created user profile for: {persona_name} (Steam ID: {steam_id})")
-                else:
-                    # Update existing user profile
-                    user.persona_name = persona_name
-                    user.profile_url = profile_url
-                    user.avatar_url = avatar
-                    user.avatarmedium = avatarmedium
-                    user.avatarfull = avatarfull
-                    user.time_created = time_created
-                    user.account_created = time_created  # For backwards compatibility
-                    user.loccountrycode = loccountrycode
-                    user.locstatecode = locstatecode
-                    user.xp = xp
-                    user.steam_level = steam_level
-                    user.last_updated = int(datetime.now().timestamp())
-                    logger.info(f"Updated user profile for: {persona_name} (Steam ID: {steam_id})")
-                
-                session.commit()
-            else:
-                # Create minimal profile if API call failed
-                if not user:
-                    user = UserProfile(
-                        steam_id=steam_id,
-                        last_updated=int(datetime.now().timestamp())
-                    )
-                    session.add(user)
-                    session.commit()
-                    logger.info(f"Created minimal user profile for Steam ID: {steam_id}")
+        # Create or update user profile (with XP/badges data for main user)
+        player_profiles = self.get_player_summaries(steam_id)
+        player_data = player_profiles[0] if player_profiles else None
+        self.save_user_profile(player_data, steam_id, include_badges=True)
         
         # Get owned games
         owned_games = self.get_owned_games(steam_id)
@@ -579,18 +669,129 @@ class SteamLibraryFetcher:
         
         logger.info(f"Completed! Processed {processed_count} games successfully. Data saved to database")
         
+        # Process friends if requested
+        if self.fetch_friends:
+            self.process_friends_data(steam_id)
+    
+    def process_friends_data(self, user_steam_id: str, batch_size: int = 100):
+        """Fetch and process friends list and their games"""
+        logger.info("\n" + "="*60)
+        logger.info("Starting friends data processing...")
+        logger.info("="*60 + "\n")
+        
+        # Get friend list
+        friends = self.get_friend_list(user_steam_id)
+        if not friends:
+            logger.warning("No friends found or profile is private")
+            return
+            
+        logger.info(f"Processing {len(friends)} friends...")
+        
+        # Save friend relationships
+        self._save_friend_relationships(user_steam_id, friends)
+        
+        # Process friends' profiles and games in batches
+        friend_ids = [f.get('steamid') for f in friends]
+        self._process_friends_in_batches(friend_ids, batch_size)
+        
+        logger.info("\nFriends data processing completed!")
+    
+    def _save_friend_relationships(self, user_steam_id: str, friends: List[Dict]):
+        """Save friend relationships to database using association table"""
+        with get_db() as session:
+            for friend_data in friends:
+                friend_steam_id = friend_data.get('steamid')
+                relationship = friend_data.get('relationship', 'friend')
+                friend_since = friend_data.get('friend_since', 0)
+                
+                # Check if friend relationship already exists
+                existing_friend = session.execute(
+                    friends_association.select().where(
+                        (friends_association.c.user_steam_id == user_steam_id) &
+                        (friends_association.c.friend_steam_id == friend_steam_id)
+                    )
+                ).first()
+                
+                if not existing_friend:
+                    session.execute(
+                        friends_association.insert().values(
+                            user_steam_id=user_steam_id,
+                            friend_steam_id=friend_steam_id,
+                            relationship=relationship,
+                            friend_since=friend_since
+                        )
+                    )
+            
+            session.commit()
+    
+    def _process_friends_in_batches(self, friend_ids: List[str], batch_size: int):
+        """Process friends' profiles and games in configurable batches"""
+        for i in range(0, len(friend_ids), batch_size):
+            batch = friend_ids[i:i + batch_size]
+            batch_str = ','.join(batch)
+            
+            logger.info(f"Fetching profiles for batch {i//batch_size + 1}/{(len(friend_ids) + batch_size - 1)//batch_size}")
+            
+            # Get player summaries for batch - reuses existing method
+            friend_profiles = self.get_player_summaries(batch_str)
+            
+            # Process each friend's profile and games
+            for profile in friend_profiles:
+                friend_steam_id = profile.get('steamid')
+                visibility = profile.get('communityvisibilitystate', 1)
+                
+                # Only process friends with public profiles (visibility = 3)
+                if visibility == 3:
+                    logger.info(f"Processing friend: {profile.get('personaname', 'Unknown')} (Steam ID: {friend_steam_id})")
+                    
+                    # Save friend's profile - reuses existing method without badges
+                    self.save_user_profile(profile, friend_steam_id, include_badges=False)
+                    
+                    # Fetch and save friend's games - reuses existing methods
+                    friend_games = self.get_owned_games(friend_steam_id)
+                    if friend_games:
+                        logger.info(f"  Found {len(friend_games)} games for {profile.get('personaname')}")
+                        
+                        # Process games using existing logic with caching
+                        for game in friend_games:
+                            try:
+                                # Reuse existing process_game method with caching
+                                game_data = self.process_game(game, 1, 1)  # Don't show progress for friends
+                                # Reuse existing save_to_database method
+                                self.save_to_database(game_data, friend_steam_id)
+                            except Exception as e:
+                                logger.debug(f"  Error processing game {game.get('name', 'Unknown')} for friend: {e}")
+                else:
+                    logger.info(f"Skipping friend with private profile: Steam ID {friend_steam_id}")
+        
 def main():
     # Load environment variables from .env file
     load_dotenv()
     
-    # Check for debug flag
-    debug = '--debug' in sys.argv
-    if debug:
+    # Setup argument parser
+    parser = argparse.ArgumentParser(description='Fetch Steam library data with caching support')
+    parser.add_argument('--debug', action='store_true', help='Enable debug logging')
+    parser.add_argument('--cache-days', type=int, default=7, 
+                       help='Maximum age in days before re-fetching game data (default: 7)')
+    parser.add_argument('--force-refresh', action='store_true',
+                       help='Force refresh all game data, ignoring cache')
+    parser.add_argument('--skip-games', action='store_true',
+                       help='Skip fetching game details entirely')
+    parser.add_argument('--friends', action='store_true',
+                       help='Also fetch friends list and their game libraries')
+    
+    args = parser.parse_args()
+    
+    # Set debug logging if requested
+    if args.debug:
         logging.getLogger().setLevel(logging.DEBUG)
     
-    # Get environment variables
+    # Get environment variables (support both .env and env vars)
     steam_id = os.getenv('STEAM_ID')
     api_key = os.getenv('STEAM_API_KEY')
+    
+    # Also check for CACHE_DAYS env var
+    cache_days = int(os.getenv('CACHE_DAYS', args.cache_days))
     
     if not steam_id or not api_key:
         logger.error("Missing environment variables!")
@@ -598,9 +799,18 @@ def main():
         sys.exit(1)
         
     logger.info(f"Starting Steam Library Fetcher for Steam ID: {steam_id}")
+    if args.force_refresh:
+        logger.info("Force refresh enabled - all game data will be re-fetched")
+    else:
+        logger.info(f"Using cache threshold of {cache_days} days")
     
     # Create fetcher and run
     fetcher = SteamLibraryFetcher(api_key)
+    fetcher.cache_days = cache_days
+    fetcher.force_refresh = args.force_refresh
+    fetcher.skip_games = args.skip_games
+    fetcher.fetch_friends = args.friends
+    
     fetcher.fetch_library_data(steam_id)
     
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Added comprehensive user profile data fetching including Steam level, XP, and account age
- Implemented friends list fetching and storage functionality
- Added new MCP tool `get_user_info` for accessing user profile data

## Changes
- Enhanced `UserProfile` model with additional fields (Steam level, XP, location, avatar URLs)
- Added friends relationship tracking in the database
- Updated Steam API client to fetch player badges and calculate Steam level
- Implemented friends data fetching in the data fetcher
- Created new MCP tool for retrieving user information

## Test plan
- [x] Run `python run_fetcher.py` to fetch fresh user data
- [x] Verify user profile data is populated in the database
- [x] Test `get_user_info` tool in Claude Desktop
- [x] Verify friends data is fetched when using `--friends` flag
- [x] Check that Steam level is correctly calculated from XP

🤖 Generated with [Claude Code](https://claude.ai/code)