### PR TITLE
Migrate MCP server from fastmcp to official mcp python-sdk

### DIFF
--- a/deploy/helm/steam-librarian/templates/deployment.yaml
+++ b/deploy/helm/steam-librarian/templates/deployment.yaml
@@ -64,6 +64,8 @@ spec:
             secretKeyRef:
               name: {{ include "steam-librarian.secretName" . }}
               key: {{ .Values.steam.existingSecretKeys.steamId }}
+        - name: FASTMCP_HOST
+          value: "0.0.0.0"
         volumeMounts:
         - name: data
           mountPath: /data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv>=1.0.1
 requests>=2.31.0
-fastmcp>=2.10.0
+mcp==1.12.2
 uvicorn>=0.27.0
 fastapi>=0.111.0
 sqlalchemy>=2.0.23

--- a/src/mcp_server/mcp_server.py
+++ b/src/mcp_server/mcp_server.py
@@ -9,7 +9,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from datetime import datetime
 from typing import Annotated, Any
 
-from fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP
 from sqlalchemy import and_, desc, func, or_
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
@@ -472,4 +472,4 @@ def get_friends_data(data_type: Annotated[str, "Type of data: 'list', 'common_ga
 
 if __name__ == "__main__":
     # Bind to 0.0.0.0 for Docker container access
-    mcp.run(transport="http", host="0.0.0.0", port=8000, path="/mcp")
+    mcp.run(transport="streamable-http")


### PR DESCRIPTION
## Summary
- Migrated from `fastmcp` to official `mcp.server.fastmcp` from the Model Context Protocol Python SDK
- Updated requirements.txt to use `mcp==1.12.2` instead of `fastmcp>=2.10.0`
- Configured streamable-http transport with proper environment variables
- Added `FASTMCP_HOST=0.0.0.0` environment variable in Helm deployment for containerized access

## Background
This migration addresses the HTTP redirect bug documented in [modelcontextprotocol/python-sdk#1115](https://github.com/modelcontextprotocol/python-sdk/pull/1115) that was not fixed in fastmcp 2.0. The official SDK provides better control over HTTP routing and eliminates the automatic redirect behavior that was causing 307 redirects from `/mcp` to `/mcp/`.

## Technical Changes
- **Import change**: `from fastmcp import FastMCP` → `from mcp.server.fastmcp import FastMCP`
- **Transport**: Updated to use `streamable-http` transport which is the recommended transport for HTTP-based MCP servers
- **Environment configuration**: Added `FASTMCP_HOST=0.0.0.0` to ensure the server binds to all interfaces in containerized environments
- **Dependencies**: Pinned to `mcp==1.12.2` for stable behavior

## Test Plan
- [x] Code linting and formatting checks pass (`make check`)
- [x] Helm chart validation passes (`make helm-lint`, `make helm-validate`)
- [x] All Python imports work correctly
- [x] MCP server starts without redirect issues

🤖 Generated with [Claude Code](https://claude.ai/code)