### PR TITLE
Fix Kubernetes permission errors by switching to nobody user

### DIFF
--- a/deploy/docker/Dockerfile.fetcher
+++ b/deploy/docker/Dockerfile.fetcher
@@ -16,12 +16,17 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy source code
 COPY src/ /app/src/
 
-# Create directory for database volume
-RUN mkdir -p /data
+# Create directory for database volume with proper permissions
+RUN mkdir -p /data && \
+    chown -R nobody:nogroup /data && \
+    chmod 755 /data
 
 # Set environment for Python
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
+
+# Switch to nobody user
+USER nobody
 
 # Default environment variables (can be overridden)
 ENV DATABASE_URL=sqlite:////data/steam_library.db

--- a/deploy/docker/Dockerfile.mcp_server
+++ b/deploy/docker/Dockerfile.mcp_server
@@ -17,12 +17,17 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy source code
 COPY src/ /app/src/
 
-# Create directory for database volume
-RUN mkdir -p /data
+# Create directories for database volume and cache
+RUN mkdir -p /data /app/cache && \
+    chown -R nobody:nogroup /app/cache && \
+    chmod 755 /app/cache
 
 # Set environment for Python
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
+
+# Switch to nobody user
+USER nobody
 
 # Default environment variables (can be overridden)
 ENV DATABASE_URL=sqlite:////data/steam_library.db

--- a/deploy/helm/steam-librarian/templates/cronjob.yaml
+++ b/deploy/helm/steam-librarian/templates/cronjob.yaml
@@ -28,11 +28,31 @@ spec:
           {{- end }}
           serviceAccountName: {{ include "steam-librarian.serviceAccountName" . }}
           restartPolicy: OnFailure
+          initContainers:
+          - name: fix-permissions
+            image: busybox:1.36
+            command: ['sh', '-c']
+            args:
+              - |
+                echo "Setting ownership of /data to nobody:nogroup (65534:65534)"
+                chown -R 65534:65534 /data
+                chmod -R 755 /data
+                echo "Permissions fixed"
+            volumeMounts:
+            - name: data
+              mountPath: /data
+            securityContext:
+              runAsUser: 0  # Run as root to change ownership
+              runAsNonRoot: false
           containers:
           - name: fetcher
+            securityContext:
+              runAsUser: 65534  # nobody user
+              runAsGroup: 65534  # nogroup
+              runAsNonRoot: true
             image: "{{ .Values.fetcher.image.repository }}:{{ .Values.fetcher.image.tag }}"
             imagePullPolicy: {{ .Values.fetcher.image.pullPolicy }}
-            command: ["python", "fetcher/steam_library_fetcher.py"]
+            command: ["python", "src/fetcher/steam_library_fetcher.py"]
             args:
             {{- range .Values.fetcher.extraArgs }}
             - {{ . | quote }}

--- a/deploy/helm/steam-librarian/templates/deployment.yaml
+++ b/deploy/helm/steam-librarian/templates/deployment.yaml
@@ -30,6 +30,22 @@ spec:
       serviceAccountName: {{ include "steam-librarian.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.mcpServer.podSecurityContext | nindent 8 }}
+      initContainers:
+      - name: fix-permissions
+        image: busybox:1.36
+        command: ['sh', '-c']
+        args:
+          - |
+            echo "Setting ownership of /data to nobody:nogroup (65534:65534)"
+            chown -R 65534:65534 /data
+            chmod -R 755 /data
+            echo "Permissions fixed"
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        securityContext:
+          runAsUser: 0  # Run as root to change ownership
+          runAsNonRoot: false
       containers:
       - name: mcp-server
         securityContext:

--- a/deploy/helm/steam-librarian/values.yaml
+++ b/deploy/helm/steam-librarian/values.yaml
@@ -121,12 +121,13 @@ mcpServer:
   
   # Pod security context
   podSecurityContext:
-    fsGroup: 2000
+    fsGroup: 65534  # nogroup
   
   # Container security context
   securityContext:
     runAsNonRoot: true
-    runAsUser: 1000
+    runAsUser: 65534  # nobody user
+    runAsGroup: 65534  # nogroup
     readOnlyRootFilesystem: false
 
   # MCP Server Configuration


### PR DESCRIPTION
## Summary
- Fixes the `PermissionError: [Errno 13] Permission denied: 'cache'` error when running the MCP server in Kubernetes
- Switches from arbitrary UID 1000 to the standard `nobody` user (UID 65534) for better security
- Adds init containers to ensure persistent volumes have correct ownership

## Changes
- **Helm Values**: Updated security contexts to use `nobody:nogroup` (65534:65534) instead of UID 1000
- **Dockerfiles**: 
  - Added cache directory creation with proper ownership
  - Both services now run as `nobody` user
  - Set correct permissions on `/data` directory
- **Init Containers**: Added to both Deployment and CronJob to fix PV ownership before main containers start
- **Bug Fix**: Corrected fetcher command path in CronJob template

## Testing
- Init containers will run as root to fix permissions, then main containers run as nobody
- The cache directory will be created with correct ownership during image build
- Persistent volumes will automatically have correct permissions on first run

## Deployment
After merging, users will need to:
1. Rebuild Docker images with the updated Dockerfiles
2. Update image tags in their values files
3. Run `helm upgrade` to apply the changes

🤖 Generated with [Claude Code](https://claude.ai/code)