### PR TITLE
Hotfix: Fix MCP tool Context parameter structure

### DIFF
--- a/src/mcp_server/tools/filter_games.py
+++ b/src/mcp_server/tools/filter_games.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any
 
+from mcp.server.fastmcp import Context
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import joinedload
 
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 @mcp.tool()
-async def filter_games(user_steam_id: str | None = None, playtime_min: float | None = None, playtime_max: float | None = None, review_summary: list[str] | None = None, maturity_rating: str | None = None, preset: str | None = None, categories: list[str] | None = None, sort_by: str | None = None) -> str:
+async def filter_games(ctx: Context, user_steam_id: str | None = None, playtime_min: float | None = None, playtime_max: float | None = None, review_summary: list[str] | None = None, maturity_rating: str | None = None, preset: str | None = None, categories: list[str] | None = None, sort_by: str | None = None) -> str:
     """Filter user's Steam library with intelligent presets and custom criteria.
 
     Args:

--- a/src/mcp_server/tools/get_friends_data.py
+++ b/src/mcp_server/tools/get_friends_data.py
@@ -13,7 +13,6 @@ from mcp_server.enhanced_user_context import (
     resolve_user_context_with_elicitation,
 )
 from mcp_server.server import mcp
-from mcp_server.user_context import resolve_user_context
 from mcp_server.validation import FriendsDataInput
 from shared.database import Game, UserGame, UserProfile, friends_association, get_db
 
@@ -21,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 @mcp.tool()
-async def get_friends_data(data_type: str, user_steam_id: str | None = None, friend_steam_id: str | None = None, game_identifier: str | None = None, ctx: Context | None = None) -> str:
+async def get_friends_data(ctx: Context, data_type: str, user_steam_id: str | None = None, friend_steam_id: str | None = None, game_identifier: str | None = None) -> str:
     """Get social gaming data including friends lists, common games, and compatibility scores.
 
     Args:
@@ -37,15 +36,11 @@ async def get_friends_data(data_type: str, user_steam_id: str | None = None, fri
     except Exception as e:
         return f"Invalid input: {str(e)}"
 
-    # Try enhanced user context resolution with elicitation if available
-    if ctx is not None:
-        user_context = await resolve_user_context_with_elicitation(input_data.user_steam_id, ctx, allow_elicitation=True)
-    else:
-        # Fallback to standard resolution
-        user_context = await resolve_user_context(input_data.user_steam_id)
+    # Try enhanced user context resolution with elicitation (ctx is always available now)
+    user_context = await resolve_user_context_with_elicitation(input_data.user_steam_id, ctx, allow_elicitation=True)
 
     if "error" in user_context:
-        error_msg = format_elicitation_error(user_context) if ctx else user_context.get("message", "Unknown error")
+        error_msg = format_elicitation_error(user_context)
         return f"User error: {error_msg}"
 
     user = user_context["user"]

--- a/src/mcp_server/tools/get_library_stats.py
+++ b/src/mcp_server/tools/get_library_stats.py
@@ -4,6 +4,7 @@ import logging
 from collections import Counter
 from typing import Any
 
+from mcp.server.fastmcp import Context
 from sqlalchemy.orm import joinedload
 
 from mcp_server.cache import cache, user_cache_key
@@ -17,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 @mcp.tool()
-async def get_library_stats(user_steam_id: str | None = None, time_period: str = "all_time", include_insights: bool = True) -> str:
+async def get_library_stats(ctx: Context, user_steam_id: str | None = None, time_period: str = "all_time", include_insights: bool = True) -> str:
     """Get comprehensive library statistics and insights for a user.
 
     Args:

--- a/src/mcp_server/tools/search_games.py
+++ b/src/mcp_server/tools/search_games.py
@@ -19,7 +19,6 @@ from mcp_server.services.genre_translator import GenreTranslator
 from mcp_server.services.mood_mapper import MoodMapper
 from mcp_server.services.similarity_finder import SimilarityFinder
 from mcp_server.services.time_normalizer import TimeNormalizer
-from mcp_server.user_context import resolve_user_context
 from mcp_server.utils.elicitation import (
     elicit_search_refinement,
     should_elicit_for_query,
@@ -31,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 @mcp.tool()
-async def search_games(query: str, user_steam_id: str | None = None, ctx: Context | None = None) -> str:
+async def search_games(ctx: Context, query: str, user_steam_id: str | None = None) -> str:
     """Natural language game search across your Steam library with intelligent parsing.
 
     Supports mood-based searches, genre detection, similarity matching, and contextual understanding.
@@ -44,21 +43,17 @@ async def search_games(query: str, user_steam_id: str | None = None, ctx: Contex
     except Exception as e:
         return f"Invalid input: {str(e)}"
 
-    # Try enhanced user context resolution with elicitation if available
-    if ctx is not None:
-        user_context = await resolve_user_context_with_elicitation(input_data.user_steam_id, ctx, allow_elicitation=True)
-    else:
-        # Fallback to standard resolution
-        user_context = await resolve_user_context(input_data.user_steam_id)
+    # Try enhanced user context resolution with elicitation (ctx is always available now)
+    user_context = await resolve_user_context_with_elicitation(input_data.user_steam_id, ctx, allow_elicitation=True)
 
     if "error" in user_context:
-        error_msg = format_elicitation_error(user_context) if ctx else user_context.get("message", "Unknown error")
+        error_msg = format_elicitation_error(user_context)
         return f"User error: {error_msg}"
 
     user = user_context["user"]
 
     # Check if query needs refinement via elicitation
-    if ctx is not None and should_elicit_for_query(input_data.query):
+    if should_elicit_for_query(input_data.query):
         refinement = await elicit_search_refinement(ctx, input_data.query)
         if refinement:
             # Apply refinement to query - this is a simplified approach


### PR DESCRIPTION
## Summary
• Fixed critical validation error where MCP tools were receiving string values instead of Context objects
• Moved Context parameter to first position in all MCP tool signatures
• Removed optional Context parameters and simplified elicitation flow
• Cleaned up unused imports after parameter restructuring

## Problem Fixed
Tools were throwing Pydantic validation errors:
```
Input should be a valid dictionary or instance of Context [type=model_type, input_value='something relaxing', input_type=str]
```

## Changes Made
• **search_games**: Context now first parameter, always uses enhanced user resolution
• **get_recommendations**: Context moved to first position, simplified elicitation handling  
• **get_friends_data**: Context parameter repositioned, removed fallback logic
• **get_library_stats**: Added Context parameter in correct position
• **filter_games**: Added Context parameter for consistency

## Testing
✅ Server imports successfully after changes
✅ All linting issues resolved
✅ MCP tools now properly receive Context objects

This enables proper MCP elicitation and completion features that were broken by the parameter structure mismatch.

🤖 Generated with [Claude Code](https://claude.ai/code)